### PR TITLE
feat(charts): add server-side query cancellation for Explore/Chart views

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -80,7 +80,7 @@ case "${1}" in
     ;;
   app)
     echo "Starting web app (using development server)..."
-    flask run -p $PORT --reload --debugger --without-threads --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*"
+    flask run -p $PORT --reload --debugger --with-threads --host=0.0.0.0 --exclude-patterns "*/node_modules/*:*/.venv/*:*/build/*:*/__pycache__/*"
     ;;
   app-gunicorn)
     echo "Starting web app..."

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -170,6 +170,8 @@ export interface QueryContext {
   result_format: string;
   queries: QueryObject[];
   form_data?: QueryFormData;
+  /** Client-generated ID for server-side query cancellation */
+  client_id?: string;
 }
 
 // Keep in sync with superset/errors.py

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -75,6 +75,7 @@ export default function chartReducer(
         chartUpdateEndTime: null,
         chartUpdateStartTime: now(),
         queryController: action.queryController,
+        clientId: action.clientId || null,
       };
     },
     [actions.CHART_UPDATE_STOPPED](state) {

--- a/superset-frontend/src/explore/types.ts
+++ b/superset-frontend/src/explore/types.ts
@@ -63,6 +63,7 @@ export interface ChartState {
   queryController: AbortController | null;
   queriesResponse: QueryData[] | null;
   triggerQuery: boolean;
+  clientId?: string | null;
 }
 
 export type OptionSortType = Partial<

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -27,7 +27,7 @@ from flask_babel import gettext as _
 from marshmallow import ValidationError
 from werkzeug.utils import secure_filename
 
-from superset import is_feature_enabled, security_manager
+from superset import db, is_feature_enabled, security_manager
 from superset.async_events.async_query_manager import AsyncQueryTokenException
 from superset.charts.api import ChartRestApi
 from superset.charts.client_processing import apply_client_processing
@@ -48,7 +48,8 @@ from superset.common.chart_data import ChartDataResultFormat, ChartDataResultTyp
 from superset.connectors.sqla.models import BaseDatasource
 from superset.daos.exceptions import DatasourceNotFound
 from superset.exceptions import QueryObjectValidationError
-from superset.extensions import event_logger
+from superset.extensions import cache_manager, event_logger
+from superset.models.core import Database
 from superset.models.sql_lab import Query
 from superset.utils import json
 from superset.utils.core import (
@@ -67,7 +68,7 @@ logger = logging.getLogger(__name__)
 
 
 class ChartDataRestApi(ChartRestApi):
-    include_route_methods = {"get_data", "data", "data_from_cache"}
+    include_route_methods = {"get_data", "data", "data_from_cache", "stop"}
 
     @expose("/<int:pk>/data/", methods=("GET",))
     @protect()
@@ -341,6 +342,70 @@ class ChartDataRestApi(ChartRestApi):
             )
 
         return self._get_data_response(command, True)
+
+    @expose("/data/stop", methods=("POST",))
+    @protect()
+    @statsd_metrics
+    def stop(self) -> Response:
+        """Stop a running chart query by client_id.
+        ---
+        post:
+          summary: Stop a running chart query
+          description: >-
+            Cancels a running chart query on the database engine using a
+            client-generated ID that was sent with the original data request.
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    client_id:
+                      type: string
+          responses:
+            200:
+              description: Query cancelled
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+        """
+        if not request.is_json or not request.json:
+            return self.response_400(message=_("Request is not JSON"))
+
+        client_id = request.json.get("client_id")
+        if not client_id:
+            return self.response_400(message=_("client_id is required"))
+
+        cancel_info = cache_manager.inflight_query_cache.get(client_id)
+        if not cancel_info:
+            return self.response_404()
+
+        database = db.session.query(Database).get(cancel_info["database_id"])
+        if not database:
+            return self.response_404()
+
+        if database.db_engine_spec.has_implicit_cancel():
+            cache_manager.inflight_query_cache.delete(client_id)
+            return self.response(200, message="Query cancelled (implicit)")
+
+        from contextlib import closing
+
+        with database.get_sqla_engine(
+            catalog=cancel_info.get("catalog"),
+            schema=cancel_info.get("schema"),
+        ) as engine:
+            with closing(engine.raw_connection()) as conn:
+                with closing(conn.cursor()) as cursor:
+                    database.db_engine_spec.cancel_query(
+                        cursor, None, cancel_info["cancel_query_id"]
+                    )
+
+        cache_manager.inflight_query_cache.delete(client_id)
+        return self.response(200, message="Query cancelled")
 
     def _run_async(
         self,

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1403,6 +1403,12 @@ class ChartDataQueryContextSchema(Schema):
     query_context_factory: QueryContextFactory | None = None
     datasource = fields.Nested(ChartDataDatasourceSchema)
     queries = fields.List(fields.Nested(ChartDataQueryObjectSchema))
+    client_id = fields.String(
+        load_default=None,
+        metadata={
+            "description": "Client-generated ID for server-side query cancellation"
+        },
+    )
     custom_cache_timeout = fields.Integer(
         metadata={"description": "Override the default cache timeout"},
         required=False,

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -71,6 +71,7 @@ class QueryContext:
         force: bool = False,
         custom_cache_timeout: int | None = None,
         cache_values: dict[str, Any],
+        client_id: str | None = None,
     ) -> None:
         self.datasource = datasource
         self.slice_ = slice_
@@ -81,6 +82,7 @@ class QueryContext:
         self.force = force
         self.custom_cache_timeout = custom_cache_timeout
         self.cache_values = cache_values
+        self.client_id = client_id
         self._processor = QueryContextProcessor(self)
 
     def get_data(

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -52,6 +52,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         result_format: ChartDataResultFormat | None = None,
         force: bool = False,
         custom_cache_timeout: int | None = None,
+        client_id: str | None = None,
     ) -> QueryContext:
         datasource_model_instance = None
         if datasource:
@@ -100,6 +101,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             force=force,
             custom_cache_timeout=custom_cache_timeout,
             cache_values=cache_values,
+            client_id=client_id,
         )
 
     def _convert_to_model(self, datasource: DatasourceDict) -> Explorable:

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -240,7 +240,10 @@ class QueryContextProcessor:
         which handles query execution, normalization, time offsets, and
         post-processing.
         """
-        return self._qc_datasource.get_query_result(query_object)
+        return self._qc_datasource.get_query_result(
+            query_object,
+            client_id=self._query_context.client_id,
+        )
 
     def get_data(
         self, df: pd.DataFrame, coltypes: list[GenericDataType]

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -134,7 +134,11 @@ class QueryCacheManager:
                 "queried_dttm": self.queried_dttm,
                 "dttm": self.queried_dttm,  # Backwards compatibility
             }
-            if self.is_loaded and key and self.status != QueryStatus.FAILED:
+            if (
+                self.is_loaded
+                and key
+                and self.status not in (QueryStatus.FAILED, QueryStatus.STOPPED)
+            ):
                 self.set(
                     key=key,
                     value=value,
@@ -166,8 +170,6 @@ class QueryCacheManager:
 
         if cache_value := _cache[region].get(key):
             logger.debug("Cache key: %s", key)
-            # Log cache hit for debugging
-            logger.debug("CACHE GET - Key: %s, Region: %s", key, region)
             current_app.config["STATS_LOGGER"].incr("loading_from_cache")
             try:
                 query_cache.df = cache_value["df"]

--- a/superset/config.py
+++ b/superset/config.py
@@ -1134,6 +1134,16 @@ EXPLORE_FORM_DATA_CACHE_CONFIG: CacheConfig = {
     "CODEC": JsonKeyValueCodec(),
 }
 
+# Cache for in-flight chart query cancel information.
+# Stores cancel_query_id so that running chart queries can be cancelled
+# server-side via POST /api/v1/chart/data/stop.
+INFLIGHT_QUERY_STATE_CACHE_CONFIG: CacheConfig = {
+    "CACHE_TYPE": "SupersetMetastoreCache",
+    "CACHE_DEFAULT_TIMEOUT": 300,
+    "CACHE_KEY_PREFIX": "inflight_query_",
+    "CODEC": JsonKeyValueCodec(),
+}
+
 # store cache keys by datasource UID (via CacheKey) for custom processing/invalidation
 STORE_CACHE_KEYS_IN_METADATA_DB = False
 

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -411,6 +411,21 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
             raise err
 
     @classmethod
+    def get_cancel_query_id(cls, cursor: Any, query: Query) -> str | None:
+        """
+        Get Trino query ID for cancellation.
+
+        The query_id is available on the cursor after execute() is called.
+
+        :param cursor: Cursor instance in which the query will be executed
+        :param query: Query instance (unused for Trino)
+        :return: Trino queryId or None
+        """
+        if hasattr(cursor, "query_id") and cursor.query_id:
+            return str(cursor.query_id)
+        return None
+
+    @classmethod
     def prepare_cancel_query(cls, query: Query) -> None:
         if QUERY_CANCEL_KEY not in query.extra:
             query.set_extra_json_key(QUERY_EARLY_CANCEL_KEY, True)

--- a/superset/explorables/base.py
+++ b/superset/explorables/base.py
@@ -72,7 +72,9 @@ class Explorable(Protocol):
     # Core Query Interface
     # =========================================================================
 
-    def get_query_result(self, query_object: QueryObject) -> QueryResult:
+    def get_query_result(
+        self, query_object: QueryObject, client_id: str | None = None
+    ) -> QueryResult:
         """
         Execute a query and return results.
 

--- a/superset/superset_typing.py
+++ b/superset/superset_typing.py
@@ -190,6 +190,9 @@ class QueryObjectDict(TypedDict, total=False):
     rls: list[Any]
     changed_on: datetime | None
 
+    # Server-side query cancellation
+    client_id: str | None
+
     # Deprecated fields (still in use)
     groupby: list[Column]
     timeseries_limit: int

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -193,6 +193,7 @@ class CacheManager:
         self._thumbnail_cache = SupersetCache()
         self._filter_state_cache = SupersetCache()
         self._explore_form_data_cache = ExploreFormDataCache()
+        self._inflight_query_cache = SupersetCache()
         self._signal_cache: RedisCacheBackend | RedisSentinelCacheBackend | None = None
 
     @staticmethod
@@ -234,6 +235,11 @@ class CacheManager:
             self._explore_form_data_cache,
             "EXPLORE_FORM_DATA_CACHE_CONFIG",
             required=True,
+        )
+        self._init_cache(
+            app,
+            self._inflight_query_cache,
+            "INFLIGHT_QUERY_STATE_CACHE_CONFIG",
         )
         self._init_signal_cache(app)
 
@@ -279,6 +285,10 @@ class CacheManager:
     @property
     def explore_form_data_cache(self) -> Cache:
         return self._explore_form_data_cache
+
+    @property
+    def inflight_query_cache(self) -> Cache:
+        return self._inflight_query_cache
 
     @property
     def signal_cache(

--- a/tests/integration_tests/sqla_models_tests.py
+++ b/tests/integration_tests/sqla_models_tests.py
@@ -1242,7 +1242,7 @@ def test_column_ordering_without_chart_flag(login_as_admin):
             }
         )
 
-        def mock_get_df(sql, catalog=None, schema=None, mutator=None):
+        def mock_get_df(sql, catalog=None, schema=None, mutator=None, client_id=None):
             """Mock get_df that calls the mutator function if provided."""
             df = mock_df.copy()
             if mutator:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

  When users click Stop in Explore, only the HTTP request was aborted while
  the database query continued running. This adds a server-side cancel
  mechanism using client_id tracking and a new POST /api/v1/chart/data/stop
  endpoint that calls db_engine_spec.cancel_query() to terminate the actual
  database query.

  - Add INFLIGHT_QUERY_STATE_CACHE_CONFIG for cancel info storage
  - Pass client_id through Schema → QueryContext → query_obj → Database
  - Capture cancel_query_id via threading for blocking engines (Trino)
  - Add TrinoEngineSpec.get_cancel_query_id() override
  - Skip caching cancelled query results (QueryStatus.STOPPED)
  - Frontend: generate client_id, call stop endpoint, show toast, clear spinner
  - Enable --with-threads for Flask dev server to handle concurrent requests
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
